### PR TITLE
feat: add cve scanning with grype, add dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@
 
 version: 2
 updates:
-  # raise PRs for gem updates
   - package-ecosystem: bundler
     directory: "/"
     schedule:
@@ -12,7 +11,6 @@ updates:
       time: "13:00"
     open-pull-requests-limit: 10
 
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -21,6 +19,13 @@ updates:
     open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "13:00"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/security_scanning.yml
+++ b/.github/workflows/security_scanning.yml
@@ -1,0 +1,43 @@
+---
+name: Security Scanning 🕵️
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build_test_container:
+    name: 'Build test container'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build local container
+        uses: docker/build-push-action@v6
+        with:
+          tags: 'ci/test:latest'
+          push: false
+
+      - name: Scan image with Anchore Grype
+        uses: anchore/scan-action@v4
+        id: scan
+        with:
+          image: 'ci/test:latest'
+          fail-build: false
+
+      - name: Inspect action SARIF report
+        run: jq . ${{ steps.scan.outputs.sarif }}
+
+      - name: Upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
grype shall run on pr and on main, otherwise the alerts in the security tab get not updated.