### PR TITLE
feat: add standard-version and conventional-changelog as alternativ changelog generators

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@semantic-release/gitlab": "^13.2.1",
     "@semantic-release/release-notes-generator": "^14.0.1",
     "conventional-changelog-conventionalcommits": "^8.0.0",
+    "conventional-changelog": "^7.1.1",
     "semantic-release-commits-lint": "^1.1.0",
     "semantic-release-github-pullrequest": "^1.3.0",
     "semantic-release-jira-notes": "^4.0.0",
@@ -16,6 +17,7 @@
     "semantic-release-major-tag": "^0.3.2",
     "semantic-release-pypi": "^4.0.1",
     "semantic-release-replace-plugin": "^1.2.7",
-    "semantic-release": "^24.1.1"
+    "semantic-release": "^24.1.1",
+    "standard-version": "^9.5.0"
   }
 }


### PR DESCRIPTION
this are stand alone tools and can do changelogs on their own, besides semantic release

don't know if it is best to put it in here or to do a new general "release" container :think: