### PR TITLE
feat: change standard-version to commit-and-tag-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Main tools in the container:
 
 - conventional-changelog
 - semantic-release
-- standard-version
+- commit-and-tag-version
 
 for more information see the [`package.json`](package.json)
 
@@ -26,8 +26,8 @@ for more information see the [`package.json`](package.json)
 # semantic-release is the default entrypoint
 podman run -it --rm -v $PWD:/data:Z ghcr.io/voxpupuli/semantic-release:latest
 
-# run standard-version
-podman run -it --rm -v $PWD:/data:Z --entrypoint standard-version ghcr.io/voxpupuli/semantic-release:latest -r v2.0.0 --skip.commit --skip.tag
+# run commit-and-tag-version
+podman run -it --rm -v $PWD:/data:Z --entrypoint commit-and-tag-version ghcr.io/voxpupuli/semantic-release:latest -r v2.0.0 --skip.commit --skip.tag
 
 # run conventional-changelog
 podman run -it --rm -v $PWD:/data:Z --entrypoint conventional-changelog ghcr.io/voxpupuli/semantic-release:latest -p angular -i CHANGELOG.md
@@ -125,7 +125,7 @@ verifyConditions:
 
 ### Example `.versionrc.json`
 
-This is an example configuration file for a project using standard-version.
+This is an example configuration file for a project using commit-and-tag-version.
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@semantic-release/github": "^11.0.0",
     "@semantic-release/gitlab": "^13.2.1",
     "@semantic-release/release-notes-generator": "^14.0.1",
+    "commit-and-tag-version": "^12.6.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "conventional-changelog": "^7.1.1",
     "semantic-release-commits-lint": "^1.1.0",
@@ -17,7 +18,6 @@
     "semantic-release-major-tag": "^0.3.2",
     "semantic-release-pypi": "^5.0.0",
     "semantic-release-replace-plugin": "^1.2.7",
-    "semantic-release": "^24.1.1",
-    "standard-version": "^9.5.0"
+    "semantic-release": "^24.1.1"
   }
 }


### PR DESCRIPTION
because standard-version is deprecated. since 2022. and I didn't saw that earlier m-)