### PR TITLE
feat: use modern git cli options

### DIFF
--- a/container-entrypoint.d/999_git_add_safe_directory.sh
+++ b/container-entrypoint.d/999_git_add_safe_directory.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-git config --global --add safe.directory '/data'
+git config set --global --append safe.directory /data


### PR DESCRIPTION
If you’re using a modern version of Git (2.48 or later), the new subcommand syntax is the recommended approach. Git introduced subcommands like get, set, unset, and list to make the CLI more consistent.