### PR TITLE
fix: restore semantic release notes generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
           tags: 'ci/semantic-release:${{ github.sha }}'
           push: false
 
+      - name: Test image
+        run: |
+          docker run --rm -v "$PWD:/data:Z" --entrypoint node ci/semantic-release:${{ github.sha }} test/release-notes.mjs
+
   tests:
     name: Test suite
     if: always()

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,14 @@
 ---
 :global:
   image_tag: 'ci/semantic-release:${{ github.sha }}'
+.github/workflows/ci.yml:
+  test_commands:
+    - >-
+      docker run --rm
+      -v "$PWD:/data:Z"
+      --entrypoint node
+      ci/semantic-release:${{ github.sha }}
+      test/release-notes.mjs
 .github/workflows/build_container.yml:
   publish_pre_build_steps:
     - name: Determine semantic-release version

--- a/README.md
+++ b/README.md
@@ -52,76 +52,28 @@ The container has the following pre-defined environment variables:
 | MATTERMOST_TAGS_URL     | `${CI_PROJECT_URL}/-/tags`                                                         |
 | MATTERMOST_USERNAME     | `Semantic Release`                                                                 |
 
-### Example `.releaserc.yaml`
+### Example release configuration
 
-This is an example configuration file for a project using semantic-release.
+See [`examples/release.config.mjs`](examples/release.config.mjs) for a complete configuration using the
+`conventionalcommits` v10 preset.
 
-```yaml
----
-branches:
- - 'main'
- - 'master'
- - 'production'
+Copy the example to the root directory of the project that should be released and name it `release.config.mjs`.
+This is the standard location that semantic-release discovers automatically:
 
-ci: true
-debug: true
-dryRun: false
-preset: 'conventionalcommits'
-
-gitlabUrl: 'https://gitlab.example.com'
-gitlabApiPathPrefix: '/api/v4'
-
-plugins:
-  - path: '@semantic-release/commit-analyzer'
-    releaseRules:
-      - { breaking: true, release: major }
-      - { type: build,    release: patch }
-      - { type: chore,    release: false }
-      - { type: ci,       release: false }
-      - { type: dep,      release: patch }
-      - { type: docs,     release: patch }
-      - { type: feat,     release: minor }
-      - { type: fix,      release: patch }
-      - { type: perf,     release: patch }
-      - { type: refactor, release: false }
-      - { type: revert,   release: patch }
-      - { type: test,     release: false }
-
-  - path: '@semantic-release/release-notes-generator'
-    writerOpts:
-      groupBy: 'type'
-      commitGroupsSort: 'title'
-      commitsSort: 'header'
-    parserOpts:
-      # detect JIRA issues in merge commits
-      issuePrefixes: ['SUP', 'BUG', 'FEATURE']
-      noteKeywords: ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
-    presetConfig:
-      issueUrlFormat: "https://jira.example.com/browse/{{prefix}}{{id}}"
-      types:
-        - { type: 'build',    section: '👷 Build' }
-        - { type: 'chore',    section: '🧹 Chores' }
-        - { type: 'ci',       section: '🚦 CI/CD' }
-        - { type: 'dep',      section: '👾 Dependencies' }
-        - { type: 'docs',     section: '📚 Docs' }
-        - { type: 'feat',     section: '🚀 Features' }
-        - { type: 'fix',      section: '🛠️ Fixes' }
-        - { type: 'perf',     section: '⏩ Performance' }
-        - { type: 'refactor', section: '🔨 Refactor' }
-        - { type: 'revert',   section: '🙅 Reverts' }
-        - { type: 'test',     section: '🚥 Tests' }
-
-  - path: '@semantic-release/changelog'
-    changelogFile: 'CHANGELOG.md'
-
-  - path: '@semantic-release/git'
-    assets:
-      - 'CHANGELOG.md'
-
-verifyConditions:
-  - '@semantic-release/changelog'
-  - '@semantic-release/git'
+```text
+your-project/
+├── release.config.mjs
+├── package.json
+└── ...
 ```
+
+Locations such as `.github/release.config.mjs` or `.gitlab/release.config.mjs` are not discovered automatically.
+They only work when semantic-release is invoked with an explicit path, for example
+`semantic-release --extends ./.github/release.config.mjs`.
+Keeping the file in the project root is recommended unless the CI command is centrally controlled.
+
+The JavaScript configuration allows the example to provide a custom JIRA URL formatter, which cannot be expressed in
+YAML.
 
 ### Example `.versionrc.json`
 
@@ -147,36 +99,49 @@ This is an example configuration file for a project using commit-and-tag-version
 
 ### Update metadata.json of a Puppet module
 
-This refers to the example config from above...
+This can be added to the example configuration:
 
-```yaml
-plugins:
-#...
-  - path: 'semantic-release-replace-plugin'
-    replacements:
-      - files: ['metadata.json']
-        from: "\"version\": \".*\""
-        to: "\"version\": \"${nextRelease.version}\""
-        countMatches: true
-        results:
-          - file: 'metadata.json'
-            hasChanged: true
-            numMatches: 1
-            numReplacements: 1
-#...
-  - path: '@semantic-release/git'
-    assets:
-      # ...
-      - 'metadata.json'
+```javascript
+plugins: [
+  // ...
+  [
+    "semantic-release-replace-plugin",
+    {
+      replacements: [
+        {
+          files: ["metadata.json"],
+          from: '"version": ".*"',
+          to: '"version": "${nextRelease.version}"',
+          countMatches: true,
+          results: [
+            {
+              file: "metadata.json",
+              hasChanged: true,
+              numMatches: 1,
+              numReplacements: 1,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  // ...
+  [
+    "@semantic-release/git",
+    {
+      assets: ["CHANGELOG.md", "metadata.json"],
+    },
+  ],
+],
 ```
 
 ### Gitlab
 
-This is a example to use this container in Gitlab.
-It requires, that you have:
+This is an example of using this container in GitLab.
+Configure semantic-release with one of the following:
 
 - A `.releaserc` file, written in YAML or JSON, with optional extensions: `.yaml` / `.yml` / `.json` / `.js` / `.cjs` / `.mjs`
-- A `release.config.(js|cjs|.mjs)` file that exports an object
+- A `release.config.(js|cjs|mjs)` file that exports an object
 - A `release` key in the project's `package.json` file
 
 ```yaml
@@ -258,21 +223,24 @@ The script accesses the environment variables:
 - `MATTERMOST_HOOK_URL`
 - `MATTERMOST_USERNAME`
 
-#### .releaserc.yaml
+#### release.config.mjs
 
-```yaml
----
-# ...
-plugins:
-# Most people will choose between one of those two:
-# ...
-  - path: '@semantic-release/exec'
-    publishCmd: "/scripts/notify-rocketchat.sh -V v${nextRelease.version} -o '--insecure' -d"
-# ...
-  - path: '@semantic-release/exec'
-    publishCmd: "/scripts/notify-mattermost.sh -V v${nextRelease.version} -o '--insecure' -d"
-# ...
-
+```javascript
+plugins: [
+  // Most people will choose between one of these two:
+  [
+    "@semantic-release/exec",
+    {
+      publishCmd: "/scripts/notify-rocketchat.sh -V v${nextRelease.version} -o '--insecure' -d",
+    },
+  ],
+  [
+    "@semantic-release/exec",
+    {
+      publishCmd: "/scripts/notify-mattermost.sh -V v${nextRelease.version} -o '--insecure' -d",
+    },
+  ],
+],
 ```
 
 #### .gitlab-ci.yml

--- a/examples/release.config.mjs
+++ b/examples/release.config.mjs
@@ -1,0 +1,60 @@
+const types = [
+  { type: "build", section: "👷 Build", effect: "bump" },
+  { type: "chore", section: "🧹 Chores", effect: "changelog" },
+  { type: "ci", section: "🚦 CI/CD", effect: "changelog" },
+  { type: "dep", section: "👾 Dependencies", effect: "bump" },
+  { type: "docs", section: "📚 Docs", effect: "bump" },
+  { type: "feat", section: "🚀 Features", effect: "bump" },
+  { type: "fix", section: "🛠️ Fixes", effect: "bump" },
+  { type: "perf", section: "⏩ Performance", effect: "bump" },
+  { type: "refactor", section: "🔨 Refactor", effect: "changelog" },
+  { type: "revert", section: "🙅 Reverts", effect: "bump" },
+  { type: "test", section: "🚥 Tests", effect: "changelog" },
+];
+
+export default {
+  branches: ["main"],
+
+  gitlabUrl: "https://gitlab.example.com",
+  gitlabApiPathPrefix: "/api/v4",
+
+  plugins: [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "conventionalcommits",
+        presetConfig: {
+          types,
+        },
+      },
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        preset: "conventionalcommits",
+        parserOpts: {
+          issuePrefixes: ["SUP-", "BUG-", "FEATURE-"],
+          noteKeywords: ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"],
+        },
+        presetConfig: {
+          types,
+          formatIssueUrl: (_context, { prefix, issue }) =>
+            `https://jira.example.com/browse/${prefix}${issue}`,
+        },
+      },
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        changelogFile: "CHANGELOG.md",
+      },
+    ],
+    [
+      "@semantic-release/git",
+      {
+        assets: ["CHANGELOG.md"],
+      },
+    ],
+    "@semantic-release/gitlab",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "@semantic-release/git": "^11.0.0",
     "@semantic-release/github": "^12.0.0",
     "@semantic-release/gitlab": "^13.2.1",
-    "@semantic-release/release-notes-generator": "^14.0.1",
+    "@semantic-release/release-notes-generator": "14.1.1",
     "commit-and-tag-version": "^13.0.0",
-    "conventional-changelog-conventionalcommits": "^10.0.0",
+    "conventional-changelog-conventionalcommits": "10.2.1",
     "conventional-changelog": "^8.0.0",
     "semantic-release-commits-lint": "^1.1.0",
     "semantic-release-github-pullrequest": "^1.3.0",
@@ -19,6 +19,11 @@
     "semantic-release-major-tag": "^0.3.2",
     "semantic-release-pypi": "^5.0.0",
     "semantic-release-replace-plugin": "^1.2.7",
-    "semantic-release": "^25.0.0"
+    "semantic-release": "25.0.8"
+  },
+  "overrides": {
+    "@semantic-release/release-notes-generator": {
+      "conventional-changelog-writer": "9.2.0"
+    }
   }
 }

--- a/test/release-notes.mjs
+++ b/test/release-notes.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+
+import releaseConfig from "../examples/release.config.mjs";
+
+const nodeModulesPath = process.env.SEMANTIC_RELEASE_NODE_MODULES || "/npm/node_modules";
+const { analyzeCommits } = await import(`${nodeModulesPath}/@semantic-release/commit-analyzer/index.js`);
+const { generateNotes } = await import(`${nodeModulesPath}/@semantic-release/release-notes-generator/index.js`);
+
+function pluginOptions(name) {
+  const plugin = releaseConfig.plugins.find((entry) => Array.isArray(entry) && entry[0] === name);
+
+  assert.ok(plugin, `Missing ${name} configuration`);
+  return plugin[1];
+}
+
+const analyzerOptions = pluginOptions("@semantic-release/commit-analyzer");
+const generatorOptions = pluginOptions("@semantic-release/release-notes-generator");
+const logger = { log() {} };
+const baseContext = {
+  cwd: process.cwd(),
+  logger,
+  options: {
+    repositoryUrl: "https://gitlab.example.com/voxpupuli/example.git",
+  },
+};
+const commits = [
+  {
+    hash: "1111111111111111111111111111111111111111",
+    message: "feat: add useful feature",
+  },
+  {
+    hash: "2222222222222222222222222222222222222222",
+    message: "fix(api): repair BUG-123",
+  },
+  {
+    hash: "3333333333333333333333333333333333333333",
+    message: "chore: document maintenance",
+  },
+];
+
+const releaseType = await analyzeCommits(analyzerOptions, {
+  ...baseContext,
+  commits,
+});
+
+assert.equal(releaseType, "minor");
+
+const choreReleaseType = await analyzeCommits(analyzerOptions, {
+  ...baseContext,
+  commits: [commits[2]],
+});
+
+assert.equal(choreReleaseType, null);
+
+const notes = await generateNotes(generatorOptions, {
+  ...baseContext,
+  commits,
+  lastRelease: {
+    gitHead: "0000000000000000000000000000000000000000",
+    gitTag: "v1.0.0",
+  },
+  nextRelease: {
+    gitHead: "3333333333333333333333333333333333333333",
+    gitTag: "v1.1.0",
+    version: "1.1.0",
+  },
+});
+
+const expectedNotes = [
+  "### 🧹 Chores",
+  "document maintenance",
+  "### 🚀 Features",
+  "add useful feature",
+  "### 🛠️ Fixes",
+  "repair BUG-123",
+  "https://jira.example.com/browse/BUG-123",
+];
+
+for (const expected of expectedNotes) {
+  assert.match(notes, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+}
+
+console.log(notes);


### PR DESCRIPTION
Align the conventional changelog preset with a compatible writer, move the v10 configuration example into a reusable project file, and verify generated release notes in CI.