### PR TITLE
fix: update git safe.directory configuration and remove redundant script

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,7 +45,7 @@ RUN apk update && apk upgrade --no-cache \
     && chmod +x /container-entrypoint.sh /container-entrypoint.d/*.sh
 
 # fix ENOGITREPO Not running from a git repository.
-RUN git config --global --add safe.directory '*'
+RUN git config set --system --append safe.directory /data
 
 WORKDIR /data
 

--- a/container-entrypoint.d/999_git_add_safe_directory.sh
+++ b/container-entrypoint.d/999_git_add_safe_directory.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-git config set --global --append safe.directory /data


### PR DESCRIPTION
The two settings can be consolidated. The entrypoint configuration is currently redundant because `safe.directory '*'` already trusts every directory and effectively disables Git’s ownership protection.

The cleaner and more restrictive solution is to configure `/data` once at the system level in the Containerfile. The `999_git_add_safe_directory.sh` entrypoint script can then be removed.

Using `--system` stores the setting in `/etc/gitconfig`, so it works with the default entrypoint, custom `--entrypoint` commands, and different runtime users regardless of their `HOME`. This assumes that the repository is mounted directly at `/data`, as documented.