### PR TITLE
feat: document/test support for running semantic-release as non-root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Test image
         run: |
           docker run --rm -v "$PWD:/data:Z" --entrypoint node ci/semantic-release:${{ github.sha }} test/release-notes.mjs
+          docker run --rm --read-only --user 65534:65534 -v "$PWD:/data:ro,Z" --entrypoint git ci/semantic-release:${{ github.sha }} rev-parse --is-inside-work-tree
 
   tests:
     name: Test suite

--- a/.sync.yml
+++ b/.sync.yml
@@ -9,6 +9,14 @@
       --entrypoint node
       ci/semantic-release:${{ github.sha }}
       test/release-notes.mjs
+    - >-
+      docker run --rm
+      --read-only
+      --user 65534:65534
+      -v "$PWD:/data:ro,Z"
+      --entrypoint git
+      ci/semantic-release:${{ github.sha }}
+      rev-parse --is-inside-work-tree
 .github/workflows/build_container.yml:
   publish_pre_build_steps:
     - name: Determine semantic-release version

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ podman run -it --rm -v $PWD:/data:Z --entrypoint commit-and-tag-version ghcr.io/
 podman run -it --rm -v $PWD:/data:Z --entrypoint conventional-changelog ghcr.io/voxpupuli/semantic-release:latest -p angular -i CHANGELOG.md
 ```
 
+To run semantic-release as the current host user instead of root, pass the host UID and GID to the container:
+
+```shell
+podman run -it --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$PWD:/data:Z" \
+  ghcr.io/voxpupuli/semantic-release:latest
+```
+
+The Git trust setting for `/data` is stored in the system-wide Git configuration, so it applies to every runtime user
+without creating a user-specific `$HOME/.gitconfig`. The mounted repository must still be writable if semantic-release
+needs to update files such as `CHANGELOG.md` or `package.json`.
+
 ### Variables
 
 The container has the following pre-defined environment variables:


### PR DESCRIPTION
fixes: #3 